### PR TITLE
Fixing Documentation Typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,13 @@ OR:
   4. On Windows, Install [pdcurses](http://pdcurses.sourceforge.net/). I have used the: pdc34dllw.zip file. See 'PDCURSES' bellow...
   5. Clone this repo locally.
 
+OR:
+- Run the ```setup_script.sh``` to install all dependencies. You can run like this:
+ ```
+chmod +x setup_script.sh
+./setup_script.sh
+```
+
 After you have the application installed, you will need:
 
   1. Register an Azure application, create a service principal, and get your tenant id. See "Using ASCiiVMSSDashboard".
@@ -152,7 +159,7 @@ as a non-block function when reading user commands. For now, use the command 'qu
 I'm looking for an alternative non-block call to use on windows and fix this.
 - It would be nice to have any feedback of this program running on MacOS or any other platform... 
 
-##PDCURSES
+## PDCURSES
 - If you have problems installing pdcurses on windows (not able to load uniCurses: import error), you can just add the DLL directly
 on the current directory of the ASCiiVMSSDashboard installation. To run the ASCiiVMSSDashboard on Windows, I have tested it 
 just cloning the repo on Windows 10, and copying the 'pdcurses.dll' file to the cloned folder, and it runs without any issues (you

--- a/README.md
+++ b/README.md
@@ -103,19 +103,19 @@ The ASCiiVMSSDashboard can run on Python 2.x or 3.x versions, and you will see t
 In case of any errors, you will be able to see the messages on the LOG Window, and also as a specific message in the main window:
 ![Image of ASCii VMSS Dashboard Error Message](https://raw.githubusercontent.com/msleal/msleal.github.com/master/error.png)
 
-###TIP #1: 
+### TIP #1: 
 To not create the .pyc files, I use the following (on Linux): export TERM=screen; export PYTHONDONTWRITEBYTECODE=1; ./console.py.
 IMPORTANT: I use 'screen' terminal and it was the best emulation I found to run curses application. You can try other terminals
 that you have the best experience or compatibility in your system (e.g.: TERM=xterm, TERM=xterm-color, etc).
 
-###TIP #2:
+### TIP #2:
 I have used the console with no issues using a refresh interval of 60 seconds. If you use a more 'agressive'
 update interval, keep one eye at the last-update registered at the top-left of the dashboard window and/or in the log
 window (e.g.: 'log'), to see if the console is stil running.  If you notice it stopped, you should see the 'ERROR' window
 described above, and the console should resume in 30 seconds. if the log has information about AZURE API 'throttling", 
 you will need to restart the ASCiiVMSSDashboard (with a bigger inteval)...
  
-###TIP #3:
+### TIP #3:
 As we wait for the threads to finish as you hit 'Ctrl+C' or 'quit' (to exit), the time you will wait to get your prompt
 back will be proportional to you refresh interval (e.g.: max='INTERVAL'). You can change the update interval in the 
 'asciivmssdashboard.json' file.

--- a/setup_script.sh
+++ b/setup_script.sh
@@ -1,0 +1,11 @@
+# really simple script to install all dependencies and run this project on debian based systems
+# to run, give this script the permission with chmod +x setup_script.sh
+# then run ./setup_script
+
+sudo apt-get install wget
+sudo apt-get install python3
+sudo apt-get install python3-pip
+sudo pip3 install azurerm
+wget https://sourceforge.net/projects/pyunicurses/files/latest/download -O unicurses.zip
+unzip unicurses.zip 
+mv PURELIB/unicurses.py .


### PR DESCRIPTION
These are really simple modification in order to fix some documentation typos. There were thee topics showing the '##' but they did not have spaces before the word in front of it. Now it's ok!